### PR TITLE
Adds self-collision to post-optimization checks.

### DIFF
--- a/trajoptpy/check_traj.py
+++ b/trajoptpy/check_traj.py
@@ -17,7 +17,7 @@ def traj_collisions(traj, robot, n=100):
             robot.SetActiveDOFValues(row)
             col_env = env.CheckCollision(robot)
             col_self = robot.CheckSelfCollision()
-            if col_env and col_self:
+            if col_env or col_self:
                 col_times.append(i)
         return col_times
 

--- a/trajoptpy/check_traj.py
+++ b/trajoptpy/check_traj.py
@@ -15,8 +15,9 @@ def traj_collisions(traj, robot, n=100):
     with robot:
         for (i, row) in enumerate(traj_up):
             robot.SetActiveDOFValues(row)
-            col_now = env.CheckCollision(robot)
-            if col_now:
+            col_env = env.CheckCollision(robot)
+            col_self = robot.CheckSelfCollision()
+            if col_env and col_self:
                 col_times.append(i)
         return col_times
 


### PR DESCRIPTION
This PR adds a self-collision check to the trajectory verification that occurs after optimization.

This catches failures where the planner fails to plan out of collision and settles into a local minima where it is still in self-collision.
